### PR TITLE
Update authors: Eliot McIntire as lead author and maintainer

### DIFF
--- a/fireSense_SpreadPredict.R
+++ b/fireSense_SpreadPredict.R
@@ -3,11 +3,11 @@ defineModule(sim, list(
   description = "Predicts a surface of fire spread probilities using a model fitted with fireSense_SpreadFit.",
   keywords = c("fire spread", "fireSense", "predict"),
   authors = c(
-    person("Jean", "Marchal", email = "jean.d.marchal@gmail.com", role = "aut"),
     person("Eliot", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca", role = c("aut", "cre")),
-    person("Tati", "Michelleti", email = "tati.micheletti@gmail.com", role = "aut"),
+    person("Tati", "Micheletti", email = "tati.micheletti@gmail.com", role = "aut"),
     person("Ian", "Eddy", email = "ian.eddy@nrcan-rncan.gc.ca", role = "aut"),
-    person("Alex M.", "Chubaty", email = "achubaty@for-cast.ca", role = c("ctb"))
+    person("Jean", "Marchal", email = "jean.d.marchal@gmail.com", role = "aut"),
+    person("Alex M.", "Chubaty", email = "achubaty@for-cast.ca", role = "ctb")
   ),
   childModules = character(),
   version = list(fireSense_SpreadPredict = "0.0.2", SpaDES.core = "0.1.0"),


### PR DESCRIPTION
Author metadata only — no code, no behaviour, no version change.

Eliot McIntire becomes lead author and maintainer (`aut`, `cre`); Jean Marchal
moves to last author. Existing middle authors keep their relative order, and
`ctb` entries are unchanged.

The rewritten `authors` block was evaluated through `utils::person()` to confirm
it parses and the roles come out as intended. `.Rmd` files render authors from
`moduleMetadata()` at build time, so they need no edit.

Also fixes a typo in the existing metadata: `"Tati Michelleti"` → `"Micheletti"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RhxSR6GHPvSqTBQ7y7pGL