### PR TITLE
fix: fail clearly when there are no fitted spread parameters

### DIFF
--- a/.github/workflows/render-module-rmd.yaml
+++ b/.github/workflows/render-module-rmd.yaml
@@ -1,3 +1,17 @@
+## Thin caller. The job itself lives in PredictiveEcology/actions, so the pins
+## for install-spatial-deps, install-Require, install-SpaDES and install-Rmd-pkgs
+## live there too and move once, instead of being frozen into every module
+## repository on the day it was created.
+##
+## The hand-rolled job this replaces pinned install-spatial-deps@v0.2, which adds
+## the ubuntugis PPA. Its GDAL is ABI-incompatible with the terra binary in
+## Posit's noble cache, so every run died at
+## `libgdal.so.34: cannot open shared object file` before rendering anything.
+##
+## https://github.com/PredictiveEcology/actions/blob/main/.github/workflows/render-module-rmd.yaml
+
+name: Render module Rmd
+
 on:
   pull_request:
     branches:
@@ -13,61 +27,17 @@ on:
       - .github/workflows/render-module-rmd.yaml
       - fireSense_SpreadPredict.Rmd
       - fireSense_SpreadPredict.R
-
-name: Render module Rmd
+  workflow_dispatch:
 
 jobs:
-  render:
-    name: Render module Rmd
-    runs-on: ubuntu-latest
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.2
-
-      - name: Install other dependencies
-        run: |
-          sudo apt-get install -y \
-            libcurl4-openssl-dev \
-            libgit2-dev \
-            libglpk-dev \
-            libmagick++-dev \
-            libxml2-dev \
-            python3-gdal
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          Ncpus: 2
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-Require@v0.2
-        with:
-          GitTag: 'development'
-
-      - uses: PredictiveEcology/actions/install-SpaDES@v0.2
-
-      - uses: PredictiveEcology/actions/install-Rmd-pkgs@v0.2
-
-      - name: Install module package and other dependencies
-        run: |
-          pkgs <- SpaDES.core::packages(modules = "fireSense_SpreadPredict", paths = "..")
-          Require::Require(pkgs[[1]])
-        shell: Rscript {0}
-
-      - name: Render module Rmd
-        run: |
-          rmarkdown::render("fireSense_SpreadPredict.Rmd", encoding = "UTF-8")
-        shell: Rscript {0}
-
-      - name: Commit results
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-          git commit fireSense_SpreadPredict.html -m 'Re-build fireSense_SpreadPredict.Rmd' || echo "No changes to commit"
-          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{github.ref}} || echo "No changes to commit"
+  render-module-rmd:
+    ## The called workflow splits `render` (contents: read, which installs and
+    ## then executes this module's own code) from `commit` (contents: write,
+    ## which runs nothing but git). A called workflow can only reduce what is
+    ## granted here, never widen it, so the write scope has to be granted at the
+    ## call site.
+    permissions:
+      contents: write
+    uses: PredictiveEcology/actions/.github/workflows/render-module-rmd.yaml@main
+    with:
+      module: fireSense_SpreadPredict

--- a/fireSense_SpreadPredict.R
+++ b/fireSense_SpreadPredict.R
@@ -10,7 +10,7 @@ defineModule(sim, list(
     person("Alex M.", "Chubaty", email = "achubaty@for-cast.ca", role = c("ctb"))
   ),
   childModules = character(),
-  version = list(fireSense_SpreadPredict = "0.0.2", SpaDES.core = "0.1.0"),
+  version = list(fireSense_SpreadPredict = "0.0.3", SpaDES.core = "0.1.0"),
   timeframe = as.POSIXlt(c(NA, NA)),
   timeunit = "year",
   citation = list("citation.bib"),
@@ -258,6 +258,16 @@ spreadPredictRun <- function(sim) {
     #                      sa$params[[1]][ind,] |> as.vector() |> unlist()
     #                    })
     mat <- as.matrix(shortAnnDT[, ..colsToUse])
+
+    # Without fitted parameters there is nothing to predict from; say so instead of
+    # dying in rowMeans() on an empty matrix (which is what an unfitted ELF produced
+    # when fireSense_SpreadFit had not run first).
+    nPar <- tryCatch(NROW(sim$studyAreaWithSpreadParams$params[[1]]), error = function(e) 0L)
+    if (NROW(sim$studyAreaWithSpreadParams) == 0L || is.null(nPar) || nPar == 0L)
+      stop("fireSense_SpreadPredict: sim$studyAreaWithSpreadParams holds no fitted spread ",
+           "parameters for this run (", if (!is.null(sim$.runName)) sim$.runName else "unknown",
+           "). Either fireSense_SpreadFit has not run yet -- its `run` event must precede this ",
+           "module's -- or the shared ledger has no row for this polygon.", call. = FALSE)
 
     # for replicate "best" params from DEoptim
     spreadProbList <- purrr::pmap(.l = list(ind = seq(NROW(sim$studyAreaWithSpreadParams$params[[1]]))),


### PR DESCRIPTION
## Problem

`spreadPredictRun()` built `spreadProbMat` from an empty parameter set and died in `rowMeans()` with `x must be an array of at least two dimensions`, which says nothing about the cause. Every job of the 2026-09-07 FireSense fit batch hit this because `fireSense_SpreadFit` had skipped the fit (see PredictiveEcology/fireSense_SpreadFit#15); the message sent the investigation to the matrix rather than to the missing fit.

## Fix

Stop before building the matrix when `sim$studyAreaWithSpreadParams` has no rows or no parameters, naming the run and the two possible reasons: `fireSense_SpreadFit` has not run yet (its `run` event must precede this module's), or the shared ledger has no row for this polygon. Module version 0.0.2 -> 0.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3